### PR TITLE
Add support for getProperties with keys passed as Array

### DIFF
--- a/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object-ts.input.ts
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object-ts.input.ts
@@ -22,4 +22,28 @@ class Thing {
       firstName: 'bob'
     });
   }
+
+  getPropertiesMethodWithArray(chancancode) {
+    let { firstName, lastName, fullName } = chancancode.getProperties([
+      'firstName',
+      'lastName',
+      'fullName'
+    ]);
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
+
+  thisGetPropertiesMethodWithArray() {
+    let { firstName, lastName, fullName } = this.getProperties([
+      'firstName',
+      'lastName',
+      'fullName'
+    ]);
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
 }

--- a/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object-ts.output.ts
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object-ts.output.ts
@@ -14,4 +14,20 @@ class Thing {
       firstName: 'bob'
     });
   }
+
+  getPropertiesMethodWithArray(chancancode) {
+    let { firstName, lastName, fullName } = chancancode;
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
+
+  thisGetPropertiesMethodWithArray() {
+    let { firstName, lastName, fullName } = this;
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
 }

--- a/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object.input.js
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object.input.js
@@ -22,4 +22,28 @@ class Thing {
       firstName: 'bob'
     });
   }
+
+  getPropertiesMethodWithArray(chancancode) {
+    let { firstName, lastName, fullName } = chancancode.getProperties([
+      'firstName',
+      'lastName',
+      'fullName'
+    ]);
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
+
+  thisGetPropertiesMethodWithArray() {
+    let { firstName, lastName, fullName } = this.getProperties([
+      'firstName',
+      'lastName',
+      'fullName'
+    ]);
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
 }

--- a/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object.output.js
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/getProperties-on-ember-object.output.js
@@ -14,4 +14,20 @@ class Thing {
       firstName: 'bob'
     });
   }
+
+  getPropertiesMethodWithArray(chancancode) {
+    let { firstName, lastName, fullName } = chancancode;
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
+
+  thisGetPropertiesMethodWithArray() {
+    let { firstName, lastName, fullName } = this;
+
+    Object.assign({}, this.getProperties(['firstName', 'lastName', 'fullName']), {
+      firstName: 'bob'
+    });
+  }
 }

--- a/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties-ts.input.ts
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties-ts.input.ts
@@ -18,4 +18,24 @@ class Thing {
   thisDotGetPropertiesMethod3() {
     let foo = this.getProperties('bar', 'baz');
   }
+
+  thisDotGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this.getProperties(['foo', 'bar', 'baz']);
+  }
+
+  nestedGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this.nested.object.getProperties([
+      'foo',
+      'bar',
+      'baz'
+    ]);
+  }
+
+  thisDotGetPropertiesMethodWithArray2() {
+    let { foo, barBaz } = this.getProperties(['foo', 'bar.baz']);
+  }
+
+  thisDotGetPropertiesMethodWithArray3() {
+    let foo = this.getProperties(['bar', 'baz']);
+  }
 }

--- a/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties-ts.output.ts
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties-ts.output.ts
@@ -14,4 +14,20 @@ class Thing {
   thisDotGetPropertiesMethod3() {
     let foo = this.getProperties('bar', 'baz');
   }
+
+  thisDotGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this;
+  }
+
+  nestedGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this.nested.object;
+  }
+
+  thisDotGetPropertiesMethodWithArray2() {
+    let { foo, barBaz } = this.getProperties(['foo', 'bar.baz']);
+  }
+
+  thisDotGetPropertiesMethodWithArray3() {
+    let foo = this.getProperties(['bar', 'baz']);
+  }
 }

--- a/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties.input.js
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties.input.js
@@ -18,4 +18,24 @@ class Thing {
   thisDotGetPropertiesMethod3() {
     let foo = this.getProperties('bar', 'baz');
   }
+
+  thisDotGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this.getProperties(['foo', 'bar', 'baz']);
+  }
+
+  nestedGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this.nested.object.getProperties([
+      'foo',
+      'bar',
+      'baz'
+    ]);
+  }
+
+  thisDotGetPropertiesMethodWithArray2() {
+    let { foo, barBaz } = this.getProperties(['foo', 'bar.baz']);
+  }
+
+  thisDotGetPropertiesMethodWithArray3() {
+    let foo = this.getProperties(['bar', 'baz']);
+  }
 }

--- a/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties.output.js
+++ b/transforms/es5-getter-ember-codemod/__testfixtures__/this-dot-getProperties.output.js
@@ -14,4 +14,20 @@ class Thing {
   thisDotGetPropertiesMethod3() {
     let foo = this.getProperties('bar', 'baz');
   }
+
+  thisDotGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this;
+  }
+
+  nestedGetPropertiesMethodWithArray() {
+    let { foo, bar, baz } = this.nested.object;
+  }
+
+  thisDotGetPropertiesMethodWithArray2() {
+    let { foo, barBaz } = this.getProperties(['foo', 'bar.baz']);
+  }
+
+  thisDotGetPropertiesMethodWithArray3() {
+    let foo = this.getProperties(['bar', 'baz']);
+  }
 }

--- a/transforms/es5-getter-ember-codemod/index.js
+++ b/transforms/es5-getter-ember-codemod/index.js
@@ -89,9 +89,15 @@ module.exports = function transformer(file, api) {
         }
 
         // check that there are no "deep" paths (e.g. "foo.bar")
-        return path.node.arguments.every(
-          (arg) => arg.value.indexOf('.') === -1
-        );
+        if (path.node.arguments.length === 1 && path.node.arguments[0].type === 'ArrayExpression') {
+          return path.node.arguments[0].elements.every(
+            (arg) => arg.value.indexOf('.') === -1
+          );
+        } else {
+          return path.node.arguments.every(
+            (arg) => arg.value.indexOf('.') === -1
+          );
+        }
       })
       .forEach((path) => {
         path.replace(path.node.callee.object);


### PR DESCRIPTION
https://api.emberjs.com/ember/release/functions/@ember%2Fobject/getProperties
https://api.emberjs.com/ember/3.17/classes/Component/methods/getProperties?anchor=getProperties

Ember getProperties can take an array of keys as argument.
This case wasn't covered previously and leads to an error.

```
    TypeError: Cannot read property 'indexOf' of undefined

      91 |         // check that there are no "deep" paths (e.g. "foo.bar")
      92 |         return path.node.arguments.every(
    > 93 |           (arg) => arg.value.indexOf('.') === -1
         |                              ^
      94 |         );
      95 |       })
      96 |       .forEach((path) => {

      at indexOf (transforms/es5-getter-ember-codemod/index.js:93:30)
          at Array.every (<anonymous>)
      at every (transforms/es5-getter-ember-codemod/index.js:92:36)
          at Array.filter (<anonymous>)
      at Collection.filter (node_modules/jscodeshift/dist/Collection.js:66:46)
      at filter (transforms/es5-getter-ember-codemod/index.js:82:8)
      at transformGetPropertiesOnObject (transforms/es5-getter-ember-codemod/index.js:167:3)
      at runInlineTest (node_modules/jscodeshift/dist/testUtils.js:28:18)
      at Object.<anonymous> (node_modules/codemod-cli/src/test-support.js:61:13)

```